### PR TITLE
Develop

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.1.{build}
+version: 2.0.{build}
 branches:
   only:
   - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ branches:
   only:
   - master
 skip_tags: true
+skip_branch_with_pr: true
 image: Visual Studio 2017
 configuration: Release
 platform: Any CPU

--- a/src/NetEx/System.Windows.Forms.CredentialDialog/CredentialDialog.cs
+++ b/src/NetEx/System.Windows.Forms.CredentialDialog/CredentialDialog.cs
@@ -11,7 +11,7 @@ using System.Windows.Forms.Internal;
 namespace System.Windows.Forms
 {
     /// <summary>
-    /// Prompts the user for credentials using a standard credential dialog. This class cannot be inherited.
+    /// Displays a standard dialog box that prompts the user to enter credentials. This class cannot be inherited.
     /// </summary>
     [DefaultEvent("HelpRequest")]
     [DefaultProperty("Username")]
@@ -22,23 +22,23 @@ namespace System.Windows.Forms
         #region Constants
 
         [SuppressMessage("ReSharper", "InconsistentNaming")]
-        public const int CREDUI_BANNER_HEIGHT = 60;
+        private const int CREDUI_BANNER_HEIGHT = 60;
         [SuppressMessage("ReSharper", "InconsistentNaming")]
-        public const int CREDUI_BANNER_WIDTH = 320;
+        private const int CREDUI_BANNER_WIDTH = 320;
         [SuppressMessage("ReSharper", "InconsistentNaming")]
-        public const int CREDUI_MAX_CAPTION_LENGTH = 128;
+        private const int CREDUI_MAX_CAPTION_LENGTH = 128;
         [SuppressMessage("ReSharper", "InconsistentNaming")]
-        public const int CREDUI_MAX_DOMAIN_TARGET_LENGTH = 337;
+        private const int CREDUI_MAX_DOMAIN_TARGET_LENGTH = 337;
         [SuppressMessage("ReSharper", "InconsistentNaming")]
-        public const int CREDUI_MAX_MESSAGE_LENGTH = 32767;
+        private const int CREDUI_MAX_MESSAGE_LENGTH = 32767;
         [SuppressMessage("ReSharper", "InconsistentNaming")]
-        public const int CREDUI_MAX_PASSWORD_LENGTH = 256;
+        private const int CREDUI_MAX_PASSWORD_LENGTH = 256;
         [SuppressMessage("ReSharper", "InconsistentNaming")]
-        public const int CREDUI_MAX_USERNAME_LENGTH = 513;
+        private const int CREDUI_MAX_USERNAME_LENGTH = 513;
         [SuppressMessage("ReSharper", "InconsistentNaming")]
-        public const int ERROR_CANCELLED = 1223;
+        private const int ERROR_CANCELLED = 1223;
         [SuppressMessage("ReSharper", "InconsistentNaming")]
-        public const int ERROR_SUCCESS = 0;
+        private const int ERROR_SUCCESS = 0;
 
         #endregion
 
@@ -57,7 +57,7 @@ namespace System.Windows.Forms
         #region Construction
 
         /// <summary>
-        /// Initializes an instance of the <see cref="CredentialDialog" /> class.
+        /// Initializes a new instance of the <see cref="CredentialDialog" /> class.
         /// </summary>
         [SuppressMessage("ReSharper", "InheritdocConsiderUsage")]
         public CredentialDialog() => Reset();
@@ -67,34 +67,31 @@ namespace System.Windows.Forms
         #region Properties
 
         /// <summary>
-        /// Gets or sets a value indicating a Windows error code to be displayed in the dialog box.
+        /// Gets or sets a value indicating a Windows error code to be displayed in the dialog box. This only applies to Windows Vista or later, and only when <see cref="AutoUpgradeEnabled"/> is set to true.
         /// </summary>
-        /// <remarks>On Windows Vista the corresponding error message is formatted and displayed in the dialog box unless <see cref="AutoUpgradeEnabled"/> is set to false.</remarks>
+        /// <value>The Windows error code for the corresponding error message to be formatted and displayed in the dialog box.</value>
         [Category("Behaviour")]
         [DefaultValue(0)]
-        [Description("Indicates why the CredentialDialog is needed.")]
+        [Description("Controls what Windows error message to show in the dialog.")]
         public int AuthenticationError { get; set; }
         /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="CredentialDialog"/> instance should automatically upgrade appearance and behavior when running on Windows Vista.
+        /// Gets or sets a value indicating whether the dialog box should automatically upgrade appearance and behavior when running on Windows Vista or later.
         /// </summary>
-        /// <value>true if this <see cref="CredentialDialog"/> instance should automatically upgrade appearance and behavior when running on Windows Vista; otherwise, false. The default is true.</value>
-        /// <remarks>
-        /// If this property is false, the <see cref="CredentialDialog"/> class will have a Windows XP-style appearance and behavior on Windows Vista.
-        /// <para>On Windows XP and Windows Server 2003, this property does not have any effect.</para>
-        /// </remarks>
+        /// <value>true if the dialog box should automatically upgrade appearance and behavior when running on Windows Vista or later; otherwise, false. The default is true.</value>
+        /// <remarks>If this property is false the dialog box will have a Windows XP-style appearance and behavior on Windows Vista. On Windows XP and Windows Server 2003 this property does not have any effect.</remarks>
         [DefaultValue(true)]
         public bool AutoUpgradeEnabled { get; set; }
         /// <summary>
         /// Gets or sets a value indicating the types of credentials that will be shown in the dialog box when running on Windows XP and Windows Server 2003, or when <see cref="AutoUpgradeEnabled"/> is set to false.
         /// </summary>
         /// <value>One of the <see cref="CredentialDialogCredentialFilter"/> values. The default value is <see cref="CredentialDialogCredentialFilter.AllCredentials"/>.</value>
-        /// <remarks>This property is only applicable on Windows XP and Windows Server 2003, or on later versions of Windows when using the <see cref="CredentialDialog"/> with <see cref="AutoUpgradeEnabled"/> set to false.</remarks>
+        /// <remarks>This property is only applicable on Windows XP and Windows Server 2003, or on later versions of Windows when using the dialog box with <see cref="AutoUpgradeEnabled"/> set to false.</remarks>
         [Category("Behaviour")]
         [DefaultValue(CredentialDialogCredentialFilter.AllCredentials)]
-        [Description("Indicates the types of credentials that will be shown in the CredentialDialog.")]
+        [Description("The types of credentials to display in the dialog.")]
         public CredentialDialogCredentialFilter CredentialFilter { get; set; }
         /// <summary>
-        /// Gets or sets a string containing the domain entered in the dialog box.
+        /// Gets or sets the domain entered in the dialog box.
         /// </summary>
         /// <value>The domain entered in the dialog box. The default value is an empty string ("").</value>
         /// <exception cref="ArgumentException">
@@ -102,7 +99,7 @@ namespace System.Windows.Forms
         /// </exception>
         [Category("Data")]
         [DefaultValue("")]
-        [Description("The domain entered in the CredentialDialog.")]
+        [Description("The domain entered in the dialog box.")]
         public string Domain
         {
             get => _domain;
@@ -110,8 +107,7 @@ namespace System.Windows.Forms
             {
                 if (value != null)
                     if (value.Length > CREDUI_MAX_DOMAIN_TARGET_LENGTH)
-                        throw new ArgumentException(
-                            $"The domain name has a maximum length of {CREDUI_MAX_DOMAIN_TARGET_LENGTH} characters.", nameof(value));
+                        throw new ArgumentException($"The domain name has a maximum length of {CREDUI_MAX_DOMAIN_TARGET_LENGTH} characters.", nameof(value));
 
                 _domain = value;
             }
@@ -119,10 +115,11 @@ namespace System.Windows.Forms
         /// <summary>
         /// Gets or sets a value indicating whether the dialog box should prevent the user from changing the supplied username when running on Windows XP and Windows Server 2003, or when <see cref="AutoUpgradeEnabled"/> is set to false.
         /// </summary>
-        /// <value>true if this <see cref="CredentialDialog"/> instance should prevent the user from changing the supplied username; otherwise, false. The default is true.</value>
+        /// <value>true if the dialog box should prevent the user from changing the supplied username; otherwise, false. The default is true.</value>
+        /// <remarks>This property is only applicable on Windows XP and Windows Server 2003, or on later versions of Windows when using the dialog box with <see cref="AutoUpgradeEnabled"/> set to false.</remarks>
         [Category("Behaviour")]
         [DefaultValue(false)]
-        [Description("Indicates whether the CredentialDialog should prevent the user from changing the username.")]
+        [Description("Controls whether the dialog box should prevent the user from changing the username.")]
         public bool DisableUsername { get; set; }
         /// <summary>
         /// Gets or sets the image that is displayed in the dialog box when running on Windows XP and Windows Server 2003, or when <see cref="AutoUpgradeEnabled"/> is set to false.
@@ -130,14 +127,14 @@ namespace System.Windows.Forms
         /// <value>The <see cref="Drawing.Image"/> to display.</value>
         /// <remarks>
         /// If this member is NULL, a default bitmap is used. The bitmap size is limited to 320x60 pixels.
-        /// <para>This property is only applicable on Windows XP and Windows Server 2003, or on later versions of Windows when using the <see cref="CredentialDialog"/> with <see cref="AutoUpgradeEnabled"/> set to false.</para>
+        /// <para>This property is only applicable on Windows XP and Windows Server 2003, or on later versions of Windows when using the dialog box with <see cref="AutoUpgradeEnabled"/> set to false.</para>
         /// </remarks>
         /// <exception cref="ArgumentException">
         /// <paramref name="value"/> does not have the correct height or width.
         /// </exception>
         [Category("Appearance")]
         [DefaultValue(null)]
-        [Description("The image displayed in the CredentialDialog.")]
+        [Description("The image to display in the dialog.")]
         public Image Image
         {
             get => _image;
@@ -158,11 +155,11 @@ namespace System.Windows.Forms
         /// <summary>
         /// Gets or sets a value indicating whether the dialog box should automatically notify the user of insufficient credentials by displaying the "Logon unsuccessful" balloon tip. This only applies when running on Windows XP and Windows Server 2003, or when <see cref="AutoUpgradeEnabled"/> is set to false.
         /// </summary>
-        /// <value>true if the credential dialog box should automatically notify the user of insufficient credentials by displaying the "Logon unsuccessful" balloon tip; otherwise, false. The default is false.</value>
-        /// <remarks>This property is only applicable on Windows XP and Windows Server 2003, or on later version of Windows when using the <see cref="CredentialDialog"/> with <see cref="AutoUpgradeEnabled"/> set to false.</remarks>
+        /// <value>true if the dialog box should automatically notify the user of insufficient credentials by displaying the "Logon unsuccessful" balloon tip; otherwise, false. The default is false.</value>
+        /// <remarks>This property is only applicable on Windows XP and Windows Server 2003, or on later versions of Windows when using the dialog box with <see cref="AutoUpgradeEnabled"/> set to false.</remarks>
         [Category("Behaviour")]
         [DefaultValue(false)]
-        [Description("Indicates whether the CredentialDialog should automatically notify the user of insufficient credentials by displaying the \"Logon unsuccessful\" balloon tip.")]
+        [Description("Controls whether the dialog box should automatically notify the user of insufficient credentials by displaying the \"Logon unsuccessful\" balloon tip.")]
         public bool IncorrectPasswordPrompt { get; set; }
         /// <summary>
         /// Gets or sets the text to display in the dialog box.
@@ -173,7 +170,7 @@ namespace System.Windows.Forms
         /// </exception>
         [Category("Appearance")]
         [DefaultValue("")]
-        [Description("The text to display in the CredentialDialog.")]
+        [Description("The text to display in the dialog.")]
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
         public string Message
         {
@@ -196,7 +193,7 @@ namespace System.Windows.Forms
         /// </exception>
         [Category("Data")]
         [DefaultValue(null)]
-        [Description("The password entered in the CredentialDialog.")]
+        [Description("The password entered in the dialog box.")]
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
         public SecureString Password
         {
@@ -217,7 +214,7 @@ namespace System.Windows.Forms
         /// <value>The value of <see cref="Password"/> converted to a <see cref="String"/>.</value>
         /// <remarks>This method is provided for debugging purposes only and is only included in debug builds.</remarks>
         [Category("Data")]
-        [Description("The password entered in the CredentialDialog.")]
+        [Description("The password entered in the dialog box.")]
         [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands")]
         public string PasswordString
         {
@@ -246,7 +243,7 @@ namespace System.Windows.Forms
         /// <remarks>The <see cref="ShowSave"/> property must be set before in order for the save check box to appear in the dialog box.</remarks>
         [Category("Behaviour")]
         [DefaultValue(false)]
-        [Description("The state of the save check box in the CredentialDialog.")]
+        [Description("The state of the save check box in the dialog.")]
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
         public bool SaveChecked
         {
@@ -259,18 +256,18 @@ namespace System.Windows.Forms
         /// <value>true if the dialog box contains a save check box; otherwise, false. The default value is true.</value>
         [Category("Appearance")]
         [DefaultValue(true)]
-        [Description("Controls whether to show the save check box in the CredentialDialog.")]
+        [Description("Controls whether to show the save check box in the dialog.")]
         public bool ShowSave { get; set; }
         /// <summary>
-        /// Gets or sets the string to display as the caption of the credential dialog box.
+        /// Gets or sets the dialog box title.
         /// </summary>
-        /// <value>The text to display in the title bar of the dialog box. The default value is an empty string ("").</value>
+        /// <value>The dialog box title. The default value is an empty string ("").</value>
         /// <exception cref="ArgumentException">
         /// <paramref name="value"/> exceeds the maximum length for the title.
         /// </exception>
         [Category("Appearance")]
         [DefaultValue("")]
-        [Description("The string to display in the title bar of the CredentialDialog.")]
+        [Description("The string to display in the title bar of the dialog box.")]
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
         public string Title
         {
@@ -285,15 +282,15 @@ namespace System.Windows.Forms
             }
         }
         /// <summary>
-        /// Gets or sets a string containing the username entered in the credential dialog box.
+        /// Gets or sets the username entered in the dialog box.
         /// </summary>
-        /// <value>The username entered in the credential dialog box. The default value is an empty string ("").</value>
+        /// <value>The username entered in the dialog box. The default value is an empty string ("").</value>
         /// <exception cref="ArgumentException">
         /// <paramref name="value"/> exceeds the maximum length for a username.
         /// </exception>
         [Category("Data")]
         [DefaultValue("")]
-        [Description("The username entered in the CredentialDialog.")]
+        [Description("The username entered in the dialog box.")]
         public string Username
         {
             get => _username;
@@ -700,7 +697,7 @@ namespace System.Windows.Forms
         #region Public
 
         /// <summary>
-        /// Resets all properties to their default values.
+        /// Resets properties to their default values.
         /// </summary>
         [SuppressMessage("ReSharper", "InheritdocConsiderUsage")]
         public override void Reset()

--- a/src/NetEx/System.Windows.Forms.CredentialDialog/CredentialDialogCredentialFilter.cs
+++ b/src/NetEx/System.Windows.Forms.CredentialDialog/CredentialDialogCredentialFilter.cs
@@ -12,8 +12,7 @@
         /// <summary>
         /// Populate the <see cref="CredentialDialog"/> with local administrators only.
         /// </summary>
-        /// <remarks>Windows XP Home Edition: This flag will filter out the well-known Administrator account.</remarks>
-        /// <remarks>Windows Vista and later: This value is intended for User Account Control (UAC) purposes only. We recommend that external callers not set this flag.</remarks>
+        /// <remarks>On Windows XP Home Edition this flag will filter out the well-known Administrator account. On Windows Vista and later this value is intended for User Account Control (UAC) purposes only. We recommend that external callers not set this flag.</remarks>
         AdministratorsOnly = 1,
         /// <summary>
         /// Populate the <see cref="CredentialDialog"/> with usernames only. This option will not display certificates or smart cards in the <see cref="CredentialDialog"/>.

--- a/src/NetEx/System.Windows.Forms.ProgressDialog/AnimationResource.cs
+++ b/src/NetEx/System.Windows.Forms.ProgressDialog/AnimationResource.cs
@@ -36,10 +36,12 @@ namespace System.Windows.Forms
         /// <summary>
         /// The filename of the resource containing the Audio-Video Interleaved (AVI) clip.
         /// </summary>
+        /// <value>A string containing the filename of the resource.</value>
         public string FileName { get; }
         /// <summary>
         /// The index of the Audio-Video Interleaved (AVI) clip within the resources contained in the file.
         /// </summary>
+        /// <value>A value represeting the index of the resource within the file.</value>
         public ushort ResourceIndex { get; }
 
         #endregion

--- a/src/NetEx/System.Windows.Forms.ProgressDialog/ProgressDialog.cs
+++ b/src/NetEx/System.Windows.Forms.ProgressDialog/ProgressDialog.cs
@@ -225,7 +225,7 @@ namespace System.Windows.Forms
 
         #region Private
 
-        private void CloseDialog()
+        private void CloseComDialog()
         {
             // If the COM dialog exists then close it and clean up
             if (_iProgressDialog != null)
@@ -271,7 +271,7 @@ namespace System.Windows.Forms
                 // Now dispose of any managed resources
 
                 // Check to make sure that the COM dialog object has been cleaned up
-                CloseDialog();
+                CloseComDialog();
 
                 // Close our reset event objects
                 _threadCompleted.Close();
@@ -438,7 +438,7 @@ namespace System.Windows.Forms
                 finally
                 {
                     // Close the dialog COM object.
-                    CloseDialog();
+                    CloseComDialog();
 
                     // Release any resources used loading an AnimationResource.
                     if (animationModuleHandle != IntPtr.Zero)

--- a/src/NetEx/System.Windows.Forms.ProgressDialog/ProgressDialog.cs
+++ b/src/NetEx/System.Windows.Forms.ProgressDialog/ProgressDialog.cs
@@ -9,7 +9,7 @@ using System.Windows.Forms.Internal;
 namespace System.Windows.Forms
 {
     /// <summary>
-    /// Informs the user of progress using a standard progress dialog. This class cannot be inherited.
+    /// Displays a standard dialog box that informs the user of the progress of an action. This class cannot be inherited.
     /// </summary> 
     [DefaultEvent("Closed")]
     [DefaultProperty("Value")]
@@ -55,7 +55,7 @@ namespace System.Windows.Forms
         #region Construction
 
         /// <summary>
-        /// Initializes an instance of the <see cref="ProgressDialog" /> class.
+        /// Initializes a new instance of the <see cref="ProgressDialog" /> class.
         /// </summary>
         [SuppressMessage("ReSharper", "InheritdocConsiderUsage")]
         public ProgressDialog() => Reset();
@@ -75,22 +75,22 @@ namespace System.Windows.Forms
         [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
         public AnimationResource Animation { get; set; }
         /// <summary>
-        /// Gets or sets a value that indicates whether the progress dialog should automatically close upon cancelation or completion. This property only applies if the progress dialog is shown using the <see cref="Show()"/> method or one of its overloads.
+        /// Gets or sets a value that indicates whether the dialog box should automatically close upon cancelation or completion. This property only applies if the progress dialog is shown using the <see cref="Show()"/> method or one of its overloads.
         /// </summary>
         /// <value>true if the dialog box should automatically close upon cancelation or completion; otherwise false.</value>
         [Category("Behavior")]
         [DefaultValue(true)]
-        [Description("Specifies whether the ProgressDialog will automatically close upon cancelation or completion.")]
+        [Description("Controls whether the dialog box will automatically close upon cancelation or completion.")]
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
         [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
         public bool AutoClose { get; set; }
         /// <summary>
-        /// Gets or sets a value that indicates whether the dialog calculates the time remaining based on its active time and progress. If this property is set to true, text can only be displayed on lines 1 and 2.
+        /// Gets or sets a value that indicates whether the dialog box calculates the time remaining based on its active time and progress. If this property is set to true, text can only be displayed on lines 1 and 2.
         /// </summary>
         /// <value>true if the dialog box automatically estimate the remaining time; otherwise, false. The default is true.</value>
         [Category("Behavior")]
         [DefaultValue(true)]
-        [Description("Specifies whether the ProgressDialog will automatically calculate the time remaining.")]
+        [Description("Controls whether the dialog box will automatically calculate the time remaining.")]
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
         [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
         public bool AutoTime { get; set; }
@@ -100,7 +100,7 @@ namespace System.Windows.Forms
         /// <value>true to display a Cancel button for the dialog box; otherwise, false. The default is true.</value>
         [Category("Appearance")]
         [DefaultValue(true)]
-        [Description("Determines whether the ProgressDialog has a cancel button. Only applies to Windows Vista and later.")]
+        [Description("Controls whether the dialog box has a cancel button. Only applies to Windows Vista and later.")]
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
         [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
         public bool CancelButton { get; set; }
@@ -122,18 +122,18 @@ namespace System.Windows.Forms
         /// <value>true to have path strings compacted if they are too large to fit on a line; otherwise, false. The default is true.</value>
         [Category("Behavior")]
         [DefaultValue(true)]
-        [Description("Determines whether the ProgressDialog truncates path strings if they are too large to fit on a line.")]
+        [Description("Controls whether the dialog box truncates path strings if they are too large to fit on a line.")]
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
         [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
         public bool CompactPath { get; set; }
         /// <summary>
-        /// Gets or sets the maximum value of the range of the control.
+        /// Gets or sets the maximum value of the range of the progress bar within the dialog box. This property has no effect if <see cref="ShowProgressBar"/> is set to false.
         /// </summary>
-        /// <value>The maximum value of the range. The default is 100.</value>
+        /// <value>The maximum value of the range of the progress bar within the dialog box. The default is 100.</value>
         [Category("Behavior")]
         [CLSCompliant(false)]
         [DefaultValue(typeof(ulong), "100")]
-        [Description("The upper bound of the range this ProgressDialog is working with.")]
+        [Description("The upper bound of the range the dialog box is working with.")]
         [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
         public ulong Maximum { get; set; }
         /// <summary>
@@ -142,7 +142,7 @@ namespace System.Windows.Forms
         /// <value>true to display a Minimize button for the dialog box; otherwise, false. The default is true.</value>
         [Category("Appearance")]
         [DefaultValue(true)]
-        [Description("Determines whether the ProgressDialog has a minimize box in the upper-right corner of its caption bar.")]
+        [Description("Determines whether the dialog box has a minimize box in the upper-right corner of its caption bar.")]
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
         [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
         public bool MinimizeBox { get; set; }
@@ -155,7 +155,7 @@ namespace System.Windows.Forms
         /// </exception>
         [Category("Appearance")]
         [DefaultValue(typeof(ProgressDialogProgressBarStyle), "Continuous")]
-        [Description("This property allows the user to set the style of the progress bar within the ProgressDialog. Only applies to Windows Vista and later.")]
+        [Description("This property allows the user to set the style of the progress bar within the dialog box. Only applies to Windows Vista and later.")]
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
         public ProgressDialogProgressBarStyle ProgressBarStyle
         {
@@ -175,7 +175,7 @@ namespace System.Windows.Forms
         /// <remarks>Typically, an application can quantitatively determine how much of the operation remains and periodically pass that value to the progress dialog box. The progress dialog box then uses this information to update its progress bar. You would typically set this property to false if the calling application must wait for an operation to finish but does not have any quantitative information it can use to update the dialog box.</remarks>
         [Category("Appearance")]
         [DefaultValue(true)]
-        [Description("Determines whether the ProgressDialog has a progress bar.")]
+        [Description("Controls whether the dialog box has a progress bar.")]
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
         [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
         public bool ShowProgressBar { get; set; }
@@ -185,30 +185,29 @@ namespace System.Windows.Forms
         /// <value>true to display the time remaining for the dialog box; otherwise, false. The default is true.</value>
         [Category("Appearance")]
         [DefaultValue(true)]
-        [Description("Determines whether the ProgressDialog shows \"time remaining\" information.")]
+        [Description("Controls whether the dialog box shows \"time remaining\" information.")]
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
         [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
         public bool ShowRemainingTime { get; set; }
         /// <summary>
-        /// Gets or sets the progress dialog box title.
+        /// Gets or sets the dialog box title.
         /// </summary>
-        /// <value>The progress dialog box title. The default value is an empty string ("").</value>
+        /// <value>The dialog box title. The default value is an empty string ("").</value>
         [Category("Appearance")]
         [DefaultValue("")]
-        [Description("The string to display in the title bar of the ProgressDialog.")]
+        [Description("The string to display in the title bar of the dialog box.")]
         [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
         [Localizable(true)]
         public string Title { get; set; }
-
         /// <summary>
-        /// Gets or sets the current position of the progress bar within the dialog box.
+        /// Gets or sets the current position of the progress bar within the dialog box. This property has no effect if <see cref="ShowProgressBar"/> is set to false.
         /// </summary>
         /// <value>The position within the range of the progress bar. The default is 0.</value>
         [Bindable(true)]
         [Category("Behavior")]
         [CLSCompliant(false)]
         [DefaultValue(typeof(ulong), "0")]
-        [Description("The current value for the ProgressDialog, in the range specified between 0 and the maximum property.")]
+        [Description("The current value for the dialog box, in the range specified between 0 and the maximum property.")]
         public ulong Value
         {
             get => _value;
@@ -242,7 +241,7 @@ namespace System.Windows.Forms
                 _iProgressDialog = null;
             }
         }
-        private void OnClosed(Boolean waitForThread)
+        private void OnClosed(bool waitForThread)
         {
             // Set a flag to indicate that the dialog has been closed - this also
             // tells our thread to stop
@@ -493,7 +492,7 @@ namespace System.Windows.Forms
         #region Public
 
         /// <summary>
-        /// Closes the progress dialog box.
+        /// Closes the dialog box.
         /// </summary>
         [SuppressMessage("ReSharper", "InvertIf")]
         public void Close()
@@ -506,7 +505,7 @@ namespace System.Windows.Forms
             OnClosed(true);
         }
         /// <summary>
-        /// Resets all properties to their default values.
+        /// Resets properties to their default values.
         /// </summary>
         [SuppressMessage("ReSharper", "InheritdocConsiderUsage")]
         public override void Reset()
@@ -522,7 +521,7 @@ namespace System.Windows.Forms
             }
         }
         /// <summary>
-        /// Displays a message in the progress dialog.
+        /// Displays a message in the dialog.
         /// </summary>
         /// <param name="line">The line number on which the text is to be displayed. Currently there are three lines — 1, 2, and 3. If <see cref="AutoTime"/> is set to true only lines 1 and 2 can be used. The estimated time will be displayed on line 3.</param>
         /// <param name="message">The message to be displayed on the line specified.</param>
@@ -542,7 +541,7 @@ namespace System.Windows.Forms
             _updated.Set();
         }
         /// <summary>
-        /// Runs a common dialog box in a non-modal fashion with a default owner.
+        /// Runs a common dialog box with a default owner in a non-modal fashion.
         /// </summary>
         [SuppressMessage("ReSharper", "IntroduceOptionalParameters.Global")]
         [SuppressMessage("ReSharper", "UnusedMember.Global")]
@@ -551,7 +550,7 @@ namespace System.Windows.Forms
             Show(null);
         }
         /// <summary>
-        /// Runs a common dialog box in a non-modal fashion with the specified owner.
+        /// Runs a common dialog box with the specified owner in a non-modal fashion.
         /// </summary>
         /// <param name="owner">Any object that implements <see cref="IWin32Window"/> that represents the top-level window that will own the modal dialog box.</param>
         public void Show(IWin32Window owner)

--- a/src/NetEx/System.Windows.Forms.ProgressDialog/ProgressDialog.cs
+++ b/src/NetEx/System.Windows.Forms.ProgressDialog/ProgressDialog.cs
@@ -395,7 +395,7 @@ namespace System.Windows.Forms
 
                             // If we are modeless raise the Canceled event.
                             if (!_modal)
-                                Canceled?.Invoke(this, EventArgs.Empty);
+                                Canceled?.BeginInvoke(this, EventArgs.Empty, null, null);
 
                             // If we are modal, or if we are modeless and AutoClose is set to
                             // true then exit the loop.
@@ -422,7 +422,7 @@ namespace System.Windows.Forms
 
                             // If we are modeless raise the Completed event.
                             if (!_modal)
-                                Completed?.Invoke(this, EventArgs.Empty);
+                                Completed?.BeginInvoke(this, EventArgs.Empty, null, null);
 
                             // If we are modal, or if we are modeless and AutoClose is set to
                             // true then exit the loop.

--- a/src/NetExDemo/NetExDemo/NetExDemo.csproj
+++ b/src/NetExDemo/NetExDemo/NetExDemo.csproj
@@ -108,16 +108,6 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\NetEx\System.Windows.Forms.CredentialDialog\System.Windows.Forms.CredentialDialog.csproj">
-      <Project>{5116d193-c76a-4e68-bd80-f9b7d55f0c0e}</Project>
-      <Name>System.Windows.Forms.CredentialDialog</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\NetEx\System.Windows.Forms.ProgressDialog\System.Windows.Forms.ProgressDialog.csproj">
-      <Project>{dad298fb-bb35-417c-b108-65d377acdaeb}</Project>
-      <Name>System.Windows.Forms.ProgressDialog</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="CredentialDialog\CredentialDialogForm.resx">
       <DependentUpon>CredentialDialogForm.cs</DependentUpon>
     </EmbeddedResource>
@@ -132,6 +122,16 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\NetEx\System.Windows.Forms.CredentialDialog\System.Windows.Forms.CredentialDialog.csproj">
+      <Project>{5116d193-c76a-4e68-bd80-f9b7d55f0c0e}</Project>
+      <Name>System.Windows.Forms.CredentialDialog</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\NetEx\System.Windows.Forms.ProgressDialog\System.Windows.Forms.ProgressDialog.csproj">
+      <Project>{dad298fb-bb35-417c-b108-65d377acdaeb}</Project>
+      <Name>System.Windows.Forms.ProgressDialog</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/NetExDemo/NetExDemo/NetExDemo.csproj
+++ b/src/NetExDemo/NetExDemo/NetExDemo.csproj
@@ -129,7 +129,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/NetExDemo/NetExDemo/ProgressDialog/ProgressDialogForm.Designer.cs
+++ b/src/NetExDemo/NetExDemo/ProgressDialog/ProgressDialogForm.Designer.cs
@@ -82,7 +82,6 @@
             this.progressDialog.Title = "progressDialog1";
             this.progressDialog.Canceled += new System.EventHandler(this.ProgressDialog_Canceled);
             this.progressDialog.Closed += new System.EventHandler(this.ProgressDialog_Closed);
-            this.progressDialog.Completed += new System.EventHandler(this.ProgressDialog_Completed);
             // 
             // ProgressDialogForm
             // 


### PR DESCRIPTION
- Update code, comments XMLdoc and Attributes for consistency. 
- Update appveyor.yaml to skip builds with open PRs.
- Fix for deadlock which occurs if Close() is called in the event handler of the Closed or Canceled events.
- Remove 'Completed' event from ProgressDialog as the event did not make sense.
- Rename CloseDialog -> CloseComDialog to better describe what the method does.

Breaking Change: The 'Completed' event has been removed from the ProgressDialog class. This event did not make sense as the dialog is always told what percentage completed the activity is, and therefore the calling application would always know whether the activity had completed. This also allows the dialog to function correctly when used in scenarios whereby the an activity is being performed which carries out several tasks, but shows the progress for each task individually.